### PR TITLE
Version 1.1.0

### DIFF
--- a/classes/class-truelayer-fields.php
+++ b/classes/class-truelayer-fields.php
@@ -172,6 +172,23 @@ class TrueLayer_Fields {
 				'default'     => '',
 				'desc_tip'    => true,
 			),
+			'truelayer_advance'                         => array(
+				'title' => 'TrueLayer Advance',
+				'type'  => 'title',
+			),
+
+			'truelayer_banking_providers'               => array(
+				'title'       => __( 'Banking Provider Types', 'truelayer-for-woocommerce' ),
+				'type'        => 'multiselect',
+				'description' => __( 'Banking Provider Types', 'truelayer-for-woocommerce' ),
+				'options'     => array(
+					'Retail'    => __( 'Retail', 'truelayer-for-woocommerce' ),
+					'Business'  => __( 'Business', 'truelayer-for-woocommerce' ),
+					'Corporate' => __( 'Corporate', 'truelayer-for-woocommerce' ),
+				),
+				'default'     => '',
+				'desc_tip'    => true,
+			),
 		);
 
 		return apply_filters( 'truelayer_gateway_settings', $settings );

--- a/classes/class-truelayer-fields.php
+++ b/classes/class-truelayer-fields.php
@@ -173,21 +173,20 @@ class TrueLayer_Fields {
 				'desc_tip'    => true,
 			),
 			'truelayer_advance'                         => array(
-				'title' => 'TrueLayer Advance',
+				'title' => __( 'TrueLayer advanced settings', 'truelayer-for-woocommerce' ),
 				'type'  => 'title',
 			),
 
 			'truelayer_banking_providers'               => array(
-				'title'       => __( 'Banking Provider Types', 'truelayer-for-woocommerce' ),
-				'type'        => 'multiselect',
-				'description' => __( 'Banking Provider Types', 'truelayer-for-woocommerce' ),
-				'options'     => array(
+				'title'    => __( 'Banking Provider Types', 'truelayer-for-woocommerce' ),
+				'type'     => 'multiselect',
+				'options'  => array(
 					'Retail'    => __( 'Retail', 'truelayer-for-woocommerce' ),
 					'Business'  => __( 'Business', 'truelayer-for-woocommerce' ),
 					'Corporate' => __( 'Corporate', 'truelayer-for-woocommerce' ),
 				),
-				'default'     => '',
-				'desc_tip'    => true,
+				'default'  => '',
+				'desc_tip' => true,
 			),
 		);
 

--- a/classes/requests/post/class-truelayer-request-create-payment.php
+++ b/classes/requests/post/class-truelayer-request-create-payment.php
@@ -66,6 +66,11 @@ class TrueLayer_Request_Create_Payment extends TrueLayer_Request_Post {
 			),
 		);
 
+		$customer_segment = $this->get_banking_providers();
+		if ( ! empty( $customer_segment ) ) {
+			$body['payment_method']['provider_selection']['filter']['customer_segments'] = $customer_segment;
+		}
+
 		return $body;
 	}
 
@@ -113,5 +118,15 @@ class TrueLayer_Request_Create_Payment extends TrueLayer_Request_Post {
 			'timeout'    => apply_filters( 'truelayer_request_timeout', 10 ),
 			'body'       => apply_filters( 'truelayer_request_args', wp_json_encode( $body ) ),
 		);
+	}
+
+	/**
+	 * Returns banking providers.
+	 *
+	 * @return array
+	 */
+	private function get_banking_providers() {
+		$banking_providers = empty( $this->settings['truelayer_banking_providers'] ) ? array() : $this->settings['truelayer_banking_providers'];
+		return array_map( 'strtolower', $banking_providers );
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -1,14 +1,14 @@
 === TrueLayer for WooCommerce ===
 Contributors: krokedil, danilokrlovic
 Tags: ecommerce, e-commerce, woocommerce, truelayer, payments, instant payments, refunds, open banking
-Requires at least: 4.5
-Tested up to: 6.0.2
-Requires PHP: 7.0
+Requires at least: 5.0
+Tested up to: 6.1.1
+Requires PHP: 7.4
 WC requires at least: 6.0.0
-WC tested up to: 6.9.4
+WC tested up to: 7.3.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
-Stable tag: 1.0.4
+Stable tag: 1.1.0
 
 TrueLayer for WooCommerce is a plugin that extends WooCommerce, allowing you to take payments via TrueLayer.
 
@@ -54,6 +54,11 @@ More information on how to get started can be found in the [plugin documentation
 6. Read more about the configuration process in the [plugin documentation](https://docs.krokedil.com/truelayer-for-woocommerce/).
 
 == CHANGELOG ==
+= 2023.02.14        - version 1.1.0 =
+* Feature           - Add support for sending different customer types in create payment request. New setting "Banking Provider Types" introduced to control this feature.
+* Tweak             - Bumped minimum required PHP version to 7.4.
+* Fix               - Fix PHP8 related error that could happen during plugin activation when TrueLayer config key was created.
+
 = 2022.09.30        - version 1.0.4 =
 * Fix               - Do not try to load plugin if WooCommerce isn't activated. Could cause fatal error.
 * Fix               - Remove enqueuing of unused admin css file.

--- a/readme.txt
+++ b/readme.txt
@@ -8,7 +8,7 @@ WC requires at least: 6.0.0
 WC tested up to: 6.9.4
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
-Stable tag: 1.0.3
+Stable tag: 1.0.4
 
 TrueLayer for WooCommerce is a plugin that extends WooCommerce, allowing you to take payments via TrueLayer.
 
@@ -54,6 +54,10 @@ More information on how to get started can be found in the [plugin documentation
 6. Read more about the configuration process in the [plugin documentation](https://docs.krokedil.com/truelayer-for-woocommerce/).
 
 == CHANGELOG ==
+= 2022.09.30        - version 1.0.4 =
+* Fix               - Do not try to load plugin if WooCommerce isn't activated. Could cause fatal error.
+* Fix               - Remove enqueuing of unused admin css file.
+
 = 2022.09.26        - version 1.0.3 =
 * Tweak             - GitHub/SVN tweak.
 

--- a/truelayer-for-woocommerce.php
+++ b/truelayer-for-woocommerce.php
@@ -109,7 +109,7 @@ if ( ! class_exists( 'TrueLayer_For_WooCommerce' ) ) {
 				return;
 			}
 			do_action( 'truelayer_plugin_activated' );
-			TrueLayer_Config_Keys::create_truelayer_key_and_save_to_wp_config();
+			TrueLayer_Config_Keys::get_instance()->create_truelayer_key_and_save_to_wp_config();
 		}
 
 		/**
@@ -121,7 +121,7 @@ if ( ! class_exists( 'TrueLayer_For_WooCommerce' ) ) {
 			if ( ! defined( 'TRUELAYER_KEY' ) ) {
 				return;
 			}
-			TrueLayer_Config_Keys::delete_truelayer_key_from_wp_config();
+			TrueLayer_Config_Keys::get_instance()->delete_truelayer_key_from_wp_config();
 		}
 
 		/**

--- a/truelayer-for-woocommerce.php
+++ b/truelayer-for-woocommerce.php
@@ -5,14 +5,14 @@
  * Description: TrueLayer for WooCommerce.
  * Author: Krokedil
  * Author URI: https://krokedil.com/
- * Version: 1.0.4
+ * Version: 1.1.0
  * Text Domain: truelayer-for-woocommerce
  * Domain Path: /languages
  *
  * WC requires at least: 6.0.0
- * WC tested up to: 6.9.4
+ * WC tested up to: 7.3.0
  *
- * Copyright (c) 2022 Krokedil
+ * Copyright (c) 2022-2023 Krokedil
  *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
@@ -29,7 +29,7 @@ use Defuse\Crypto\Key;
 define( 'TRUELAYER_WC_MAIN_FILE', __FILE__ );
 define( 'TRUELAYER_WC_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'TRUELAYER_WC_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'TRUELAYER_WC_PLUGIN_VERSION', '1.0.4' );
+define( 'TRUELAYER_WC_PLUGIN_VERSION', '1.1.0' );
 
 if ( ! class_exists( 'TrueLayer_For_WooCommerce' ) ) {
 	/**

--- a/truelayer-for-woocommerce.php
+++ b/truelayer-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: TrueLayer for WooCommerce.
  * Author: Krokedil
  * Author URI: https://krokedil.com/
- * Version: 1.0.3
+ * Version: 1.0.4
  * Text Domain: truelayer-for-woocommerce
  * Domain Path: /languages
  *
@@ -29,7 +29,7 @@ use Defuse\Crypto\Key;
 define( 'TRUELAYER_WC_MAIN_FILE', __FILE__ );
 define( 'TRUELAYER_WC_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'TRUELAYER_WC_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'TRUELAYER_WC_PLUGIN_VERSION', '1.0.3' );
+define( 'TRUELAYER_WC_PLUGIN_VERSION', '1.0.4' );
 
 if ( ! class_exists( 'TrueLayer_For_WooCommerce' ) ) {
 	/**


### PR DESCRIPTION
* Feature - Add support for sending different customer types in create payment request. New setting "Banking Provider Types" introduced to control this feature.
* Tweak - Bumped minimum required PHP version to 7.4.
* Fix - Fix PHP8 related error that could happen during plugin activation when TrueLayer config key was created.