### PR TITLE
Create Payment Request - add address and date of birth to user object

### DIFF
--- a/classes/requests/helpers/class-truelayer-helper-order.php
+++ b/classes/requests/helpers/class-truelayer-helper-order.php
@@ -43,4 +43,17 @@ class TrueLayer_Helper_Order {
 
 		return $account_holder_name;
 	}
+
+    /**
+     * Get order meta - user date of birth
+     * @param $order
+     * @return mixed
+     */
+    public static function get_user_date_of_birth( $order ) {
+
+        $birth_date = apply_filters('truelayer_birth_date_field', $order->get_meta( '_truelayer_user_birth_date', true ), $order->get_id(), $order);
+
+        return $birth_date;
+
+    }
 }

--- a/classes/requests/post/class-truelayer-request-create-payment.php
+++ b/classes/requests/post/class-truelayer-request-create-payment.php
@@ -60,11 +60,23 @@ class TrueLayer_Request_Create_Payment extends TrueLayer_Request_Post {
 					),
 				),
 			),
-			'user'            => array(
-				'name'  => TrueLayer_Helper_Order::get_account_holder_name( $order ),
-				'email' => $order->get_billing_email(),
-			),
-		);
+            'user'            => array(
+                'name'  => TrueLayer_Helper_Order::get_account_holder_name( $order ),
+                'email' => $order->get_billing_email(),
+                'address' => array(
+                    'address_line1' => $order->get_billing_address_1(),
+                    'address_line2' => $order->get_billing_address_2(),
+                    'city' => $order->get_billing_city(),
+                    'state' => $order->get_billing_state(),
+                    'zip' => $order->get_billing_postcode(),
+                    'country_code' => $order->get_billing_country(),
+                ),
+            ),
+        );
+
+        if( ! empty( $birth_date = TrueLayer_Helper_Order::get_user_date_of_birth( $order ) ) ) {
+            $body['user']['date_of_birth'] = $birth_date;
+        }
 
 		$customer_segment = $this->get_banking_providers();
 		if ( ! empty( $customer_segment ) ) {


### PR DESCRIPTION
Address details and user date of birth are added to the user object on create payment request.
User date of birth saved as order meta '_truelayer_user_birth_date' - filter: truelayer_birth_date_field
Address data fetched from WC order billing fields.