### PR TITLE
Version 1.3.0

### DIFF
--- a/classes/class-truelayer-assets.php
+++ b/classes/class-truelayer-assets.php
@@ -98,7 +98,7 @@ class TrueLayer_Assets {
 	 * @return bool
 	 */
 	protected function check_for_load_assets() {
-		$section = filter_input( INPUT_GET, 'section', FILTER_SANITIZE_STRING );
+		$section = filter_input( INPUT_GET, 'section', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		if ( empty( $section ) || 'truelayer' !== $section ) {
 			return false;
 		}

--- a/classes/class-truelayer-confirmation.php
+++ b/classes/class-truelayer-confirmation.php
@@ -28,8 +28,8 @@ class TrueLayer_Redirect {
 	 */
 	public function maybe_redirect() {
 
-		$transaction_id = filter_input( INPUT_GET, 'payment_id', FILTER_SANITIZE_STRING );
-		$error          = filter_input( INPUT_GET, 'error', FILTER_SANITIZE_STRING );
+		$transaction_id = filter_input( INPUT_GET, 'payment_id', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$error          = filter_input( INPUT_GET, 'error', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		$query_args = array(
 			'fields'      => 'ids',

--- a/classes/class-truelayer-fields.php
+++ b/classes/class-truelayer-fields.php
@@ -189,6 +189,14 @@ class TrueLayer_Fields {
 				'desc_tip' => true,
 			),
 
+			'truelayer_release_channel'                     => array(
+				'title'       => __( 'Release channel', 'truelayer-for-woocommerce' ),
+				'type'        => 'text',
+				'description' => __( 'Enter the release channel that you wish to use for TrueLayer', 'truelayer-for-woocommerce' ),
+				'default'     => '',
+				'desc_tip'    => true,
+			),
+
 			'truelayer_payment_page_type'               => array(
 				'title'    => __( 'Payments Page Types', 'truelayer-for-woocommerce' ),
 				'type'     => 'select',

--- a/classes/class-truelayer-gateway.php
+++ b/classes/class-truelayer-gateway.php
@@ -164,8 +164,8 @@ class TrueLayer_Payment_Gateway extends WC_Payment_Gateway {
 	 * @return array
 	 */
 	public function process_payment( $order_id ) {
-                $settings = get_option( 'woocommerce_truelayer_settings', array() );
-                $epp_enabled  = $settings['truelayer_payment_page_type'] ?? 'HPP';
+		$settings    = get_option( 'woocommerce_truelayer_settings', array() );
+		$epp_enabled = $settings['truelayer_payment_page_type'] ?? 'HPP';
 
 		$response = TrueLayer()->api->create_payment( $order_id );
 

--- a/classes/class-truelayer-gateway.php
+++ b/classes/class-truelayer-gateway.php
@@ -85,7 +85,6 @@ class TrueLayer_Payment_Gateway extends WC_Payment_Gateway {
 			$client_secret      = 'truelayer_client_secret';
 			$client_certificate = 'truelayer_client_certificate';
 		}
-		$settings             = get_option( 'woocommerce_truelayer_settings', array() );
 		$truelayer_options    = array( $private_key, $client_secret, $client_certificate );
 		$truelayer_encryption = Truelayer_Encryption::get_instance();
 		if ( ! empty( $settings[ $key ] ) ) {

--- a/classes/class-truelayer-gateway.php
+++ b/classes/class-truelayer-gateway.php
@@ -13,8 +13,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Class TrueLayer_Payment_Gateway.
  */
 class TrueLayer_Payment_Gateway extends WC_Payment_Gateway {
-
-
 	/**
 	 * Allowed currencies.
 	 *
@@ -28,6 +26,13 @@ class TrueLayer_Payment_Gateway extends WC_Payment_Gateway {
 	 * @var string
 	 */
 	public $testmode;
+
+	/**
+	 * The plugin logging setting value.
+	 *
+	 * @var string
+	 */
+	public $logging;
 
 	/**
 	 * Class constructor.

--- a/classes/class-truelayer-gateway.php
+++ b/classes/class-truelayer-gateway.php
@@ -28,13 +28,6 @@ class TrueLayer_Payment_Gateway extends WC_Payment_Gateway {
 	public $testmode;
 
 	/**
-	 * The plugin logging setting value.
-	 *
-	 * @var string
-	 */
-	public $logging;
-
-	/**
 	 * Class constructor.
 	 */
 	public function __construct() {
@@ -56,7 +49,6 @@ class TrueLayer_Payment_Gateway extends WC_Payment_Gateway {
 		$this->description = $this->get_option( 'description' );
 
 		$this->testmode = $this->get_option( 'testmode' );
-		$this->logging  = $this->get_option( 'logging' );
 
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( &$this, 'process_admin_options' ) );
 		add_action(

--- a/classes/requests/post/class-truelayer-request-create-payment.php
+++ b/classes/requests/post/class-truelayer-request-create-payment.php
@@ -86,6 +86,11 @@ class TrueLayer_Request_Create_Payment extends TrueLayer_Request_Post {
 			$body['payment_method']['provider_selection']['filter']['customer_segments'] = $customer_segment;
 		}
 
+		$release_channel = $this->get_release_channel();
+		if ( ! empty( $release_channel ) ) {
+			$body['payment_method']['provider_selection']['filter']['release_channel'] = $release_channel;
+		}
+
 		return $body;
 	}
 
@@ -143,5 +148,15 @@ class TrueLayer_Request_Create_Payment extends TrueLayer_Request_Post {
 	private function get_banking_providers() {
 		$banking_providers = empty( $this->settings['truelayer_banking_providers'] ) ? array() : $this->settings['truelayer_banking_providers'];
 		return array_map( 'strtolower', $banking_providers );
+	}
+
+	/**
+	 * Returns the release channel
+	 *
+	 * @return array
+	 */
+	private function get_release_channel() {
+		$release_channel = empty( $this->settings['truelayer_release_channel'] ) ? array() : $this->settings['truelayer_release_channel'];
+		return $release_channel;
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -9,5 +9,8 @@
         "platform": {
             "php": "7.4"
         }
+    },
+    "require-dev": {
+        "php-stubs/woocommerce-stubs": "^8.1"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4e1252d8b7ab490329509e8e844d157f",
+    "content-hash": "e010ccaf3d551c29c897b5377b4c357c",
     "packages": [
         {
             "name": "brick/math",
@@ -1276,7 +1276,96 @@
             "time": "2021-01-21T19:18:03+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "php-stubs/woocommerce-stubs",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/woocommerce-stubs.git",
+                "reference": "f5a8621ca0a28c93b37b827ef92e7b49ad3d1923"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/f5a8621ca0a28c93b37b827ef92e7b49ad3d1923",
+                "reference": "f5a8621ca0a28c93b37b827ef92e7b49ad3d1923",
+                "shasum": ""
+            },
+            "require": {
+                "php-stubs/wordpress-stubs": "^5.3 || ^6.0"
+            },
+            "require-dev": {
+                "php": "~7.1 || ~8.0",
+                "php-stubs/generator": "^0.8.0"
+            },
+            "suggest": {
+                "symfony/polyfill-php73": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WooCommerce function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/woocommerce-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "woocommerce",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/woocommerce-stubs/issues",
+                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v8.1.0"
+            },
+            "time": "2023-09-12T20:25:04+00:00"
+        },
+        {
+            "name": "php-stubs/wordpress-stubs",
+            "version": "v6.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wordpress-stubs.git",
+                "reference": "adda7609e71d5f4dc7b87c74f8ec9e3437d2e92c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/adda7609e71d5f4dc7b87c74f8ec9e3437d2e92c",
+                "reference": "adda7609e71d5f4dc7b87c74f8ec9e3437d2e92c",
+                "shasum": ""
+            },
+            "require-dev": {
+                "nikic/php-parser": "^4.13",
+                "php": "^7.4 || ~8.0.0",
+                "php-stubs/generator": "^0.8.3",
+                "phpdocumentor/reflection-docblock": "^5.3",
+                "phpstan/phpstan": "^1.10.12",
+                "phpunit/phpunit": "^9.5"
+            },
+            "suggest": {
+                "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/wordpress-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.3.0"
+            },
+            "time": "2023-08-10T16:34:11+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],

--- a/readme.txt
+++ b/readme.txt
@@ -2,10 +2,10 @@
 Contributors: krokedil, danilokrlovic
 Tags: ecommerce, e-commerce, woocommerce, truelayer, payments, instant payments, refunds, open banking
 Requires at least: 5.0
-Tested up to: 6.2.2
+Tested up to: 6.3
 Requires PHP: 7.4
 WC requires at least: 6.0.0
-WC tested up to: 7.8.2
+WC tested up to: 8.0.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 Stable tag: 1.2.0

--- a/readme.txt
+++ b/readme.txt
@@ -2,13 +2,13 @@
 Contributors: krokedil, danilokrlovic
 Tags: ecommerce, e-commerce, woocommerce, truelayer, payments, instant payments, refunds, open banking
 Requires at least: 5.0
-Tested up to: 6.3
+Tested up to: 6.3.1
 Requires PHP: 7.4
 WC requires at least: 6.0.0
-WC tested up to: 8.0.2
+WC tested up to: 8.1.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
-Stable tag: 1.2.1
+Stable tag: 1.3.0
 
 TrueLayer for WooCommerce is a plugin that extends WooCommerce, allowing you to take payments via TrueLayer.
 
@@ -54,6 +54,10 @@ More information on how to get started can be found in the [plugin documentation
 6. Read more about the configuration process in the [plugin documentation](https://docs.krokedil.com/truelayer-for-woocommerce/).
 
 == CHANGELOG ==
+= 2023.09.19        - version 1.3.0 =
+* Feature           - Add feature to set a custom release channel for the payment in TrueLayer. This can be set on the settings page for the plugin in the setting "Release channel". If left empty no release channel will be sent to Truelayer.
+* Fix               - Fixed some deprecation warnings for PHP version 8.2+.
+
 = 2023.09.15        - version 1.2.1 =
 * Fix               - Remove sensitive data from logs
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires at least: 5.0
 Tested up to: 6.2.2
 Requires PHP: 7.4
 WC requires at least: 6.0.0
-WC tested up to: 7.8.1
+WC tested up to: 7.8.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 Stable tag: 1.2.0

--- a/readme.txt
+++ b/readme.txt
@@ -2,10 +2,10 @@
 Contributors: krokedil, danilokrlovic
 Tags: ecommerce, e-commerce, woocommerce, truelayer, payments, instant payments, refunds, open banking
 Requires at least: 5.0
-Tested up to: 6.2.0
+Tested up to: 6.2.2
 Requires PHP: 7.4
 WC requires at least: 6.0.0
-WC tested up to: 7.6.1
+WC tested up to: 7.8.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 Stable tag: 1.2.0

--- a/readme.txt
+++ b/readme.txt
@@ -55,7 +55,7 @@ More information on how to get started can be found in the [plugin documentation
 
 == CHANGELOG ==
 = 2023.09.19        - version 1.3.0 =
-* Feature           - Add feature to set a custom release channel for the payment in TrueLayer. This can be set on the settings page for the plugin in the setting "Release channel". If left empty no release channel will be sent to Truelayer.
+* Feature           - Add feature to set a custom release channel for the payment in TrueLayer. This can be set on the settings page for the plugin in the setting "Release channel". If left empty no release channel will be sent to TrueLayer.
 * Fix               - Fixed some deprecation warnings for PHP version 8.2+.
 
 = 2023.09.15        - version 1.2.1 =

--- a/truelayer-for-woocommerce.php
+++ b/truelayer-for-woocommerce.php
@@ -10,7 +10,7 @@
  * Domain Path: /languages
  *
  * WC requires at least: 6.0.0
- * WC tested up to: 7.8.2
+ * WC tested up to: 8.0.2
  *
  * Copyright (c) 2022-2023 Krokedil
  *

--- a/truelayer-for-woocommerce.php
+++ b/truelayer-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: TrueLayer for WooCommerce.
  * Author: Krokedil
  * Author URI: https://krokedil.com/
- * Version: 1.2.1
+ * Version: 1.3.0
  * Text Domain: truelayer-for-woocommerce
  * Domain Path: /languages
  *
@@ -29,7 +29,7 @@ use Defuse\Crypto\Key;
 define( 'TRUELAYER_WC_MAIN_FILE', __FILE__ );
 define( 'TRUELAYER_WC_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'TRUELAYER_WC_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'TRUELAYER_WC_PLUGIN_VERSION', '1.2.1' );
+define( 'TRUELAYER_WC_PLUGIN_VERSION', '1.3.0' );
 
 if ( ! class_exists( 'TrueLayer_For_WooCommerce' ) ) {
 	/**

--- a/truelayer-for-woocommerce.php
+++ b/truelayer-for-woocommerce.php
@@ -10,7 +10,7 @@
  * Domain Path: /languages
  *
  * WC requires at least: 6.0.0
- * WC tested up to: 7.6.1
+ * WC tested up to: 7.8.1
  *
  * Copyright (c) 2022-2023 Krokedil
  *

--- a/truelayer-for-woocommerce.php
+++ b/truelayer-for-woocommerce.php
@@ -10,7 +10,7 @@
  * Domain Path: /languages
  *
  * WC requires at least: 6.0.0
- * WC tested up to: 7.8.1
+ * WC tested up to: 7.8.2
  *
  * Copyright (c) 2022-2023 Krokedil
  *


### PR DESCRIPTION
- Feature - Add feature to set a custom release channel for the payment in TrueLayer. This can be set on the settings page for the plugin in the setting "Release channel". If left empty no release channel will be sent to TrueLayer.
- Fix - Fixed some deprecation warnings for PHP version 8.2+.

Also added a composer package for WooCommerce stubs to provide IDEs with function and class references for both WooCommerce and WordPress without having the source code for them included in the project